### PR TITLE
컨트리뷰터 파싱 관련 버그 픽스

### DIFF
--- a/app/Services/Github/ContributorSearcher.php
+++ b/app/Services/Github/ContributorSearcher.php
@@ -122,7 +122,7 @@ class ContributorSearcher
 
         if (count($contributors) == 0) {
 
-            $node = $this->crawler->filter('.f6 a')->first();
+            $node = $this->crawler->filter('.Details a')->first();
 
 
             $userUrl = "https://github.com".$node->attr('href');


### PR DESCRIPTION
Closes #41 

돔 트리에서 `.f6` 클래스가 사라지고, 바뀐 돔에서 다른 적절해 보이는 유니크한 클래스인 `.Details`로 대체했습니다.